### PR TITLE
LU-4882 Check variable containing 'processed blob file path'

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ Three SSH steps are carried out:
 5. The k8s repository carries out the deployment. If successful it copies the new bsm.yaml to the dev branch in the k8s repo.
 
 6. Upon successful build of step 4 and 5 - it copies and does a commit (push) of the manifest (containing the bcv.yaml file) to the dev branch of the k8s repo ( A GCP Trigger on the dev branch initiates a build based on the cloudbuild-delivery.yaml ).
+
+

--- a/blaise_nisra_case_mover_sftp.py
+++ b/blaise_nisra_case_mover_sftp.py
@@ -49,7 +49,8 @@ def main():
                 if file_blob is None:
                     upload_blob(source_file_name=file,
                                 destination_blob_name=blob_destination_path)
-                elif file_same_as_bucket_file(file, file_blob) or file_same_as_bucket_file(file, file_blob_processed):
+                elif file_same_as_bucket_file(file, file_blob) or (file_blob_processed is not None and
+                                                                   file_same_as_bucket_file(file, file_blob_processed)):
                     log.info('Ignoring file {} because its unchanged'.format(file))
                 else:
                     upload_blob(source_file_name=file,

--- a/bncm-cronjob.yaml.tpl
+++ b/bncm-cronjob.yaml.tpl
@@ -1,20 +1,20 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: nisra-mover-opn1911a
+  name: nisra-mover-opn2001a
 spec:
-  schedule: "*/5 * * * *"
+  schedule: "*/60 * * * *"
   successfulJobsHistoryLimit: 5
   jobTemplate:
     spec:
       template:
         spec:
           containers:
-          - name: nisra-mover-opn1911a-container
+          - name: nisra-mover-opn2001a-container
             image: "eu.gcr.io/GOOGLE_CLOUD_PROJECT/blaise-nisra-case-mover-sftp:COMMIT_SHA"
             env:
               - name: SURVEY_DESTINATION_PATH
-                value: 'opn/opn1911a/'
+                value: 'opn/opn2001a/'
               - name: SURVEY_SOURCE_PATH_PREFIX
                 value: 'ONS/'
               - name: NISRA_BUCKET_NAME


### PR DESCRIPTION
Check variable containing 'processed blob file path' that it is 
not None before calling file_same_as_bucket_file()

Code fix made because if above method is called with variable set to None (so no file existing in the processed file path) it errors with : "'NoneType' object has no attribute 'name'" when trying to to run line 101 e.g. _log.info('Comparing file {} to blob {}.'.format(file, file_blob.name))_

Also updated schedule and changed survey name