### PR TITLE
Reverting Rich's breakdown

### DIFF
--- a/bncm-cronjob.yaml.tpl
+++ b/bncm-cronjob.yaml.tpl
@@ -18,10 +18,7 @@ spec:
               - name: SURVEY_SOURCE_PATH_PREFIX
                 value: 'ONS/'
               - name: NISRA_BUCKET_NAME
-                valueFrom:
-                  configMapKeyRef:
-                    name: blaise-buckets
-                    key: bucket-name-nisra
+                value: 'nisra-transfer'
               - name: SFTP_HOST
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
config map doesn't exist in dev - this can be changed later when we move to new dev. 