### PR TITLE
Sets bucket name to [project_id]-nisra

### DIFF
--- a/bncm.yaml.tpl
+++ b/bncm.yaml.tpl
@@ -18,7 +18,7 @@ spec:
               - name: SURVEY_SOURCE_PATH_PREFIX
                 value: 'ONS/'
               - name: NISRA_BUCKET_NAME
-                value: 'nisra-transfer'
+                value: 'GOOGLE_CLOUD_PROJECT-nisra'
               - name: SFTP_HOST
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
### What's up
This template doesn't currently match our terraform configuration. 

### This PR:
Sets bucket to match [the one in terraform](https://github.com/ONSdigital/blaise-setup-gcp/blob/0bba064d6490d5b78c16ae645cc90647130e87e7/gcs.tf#L19)