### PR TITLE
Promote from python-client-use-release to main

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -108,7 +108,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "blaise-restapi"
-version = "1.0.4"
+version = "1.0.5"
 description = "Client for calling Blaise RestAPI"
 optional = false
 python-versions = "^3.9"
@@ -121,8 +121,8 @@ requests = "^2.26.0"
 [package.source]
 type = "git"
 url = "https://github.com/ONSdigital/blaise-api-python-client.git"
-reference = "main"
-resolved_reference = "fb5cdbbfc976a95809273d7b9c68c7be47fe2660"
+reference = "b66777bd0be8f562c7e519e16808fd4e9fadc6d2"
+resolved_reference = "b66777bd0be8f562c7e519e16808fd4e9fadc6d2"
 
 [[package]]
 name = "blinker"
@@ -1809,4 +1809,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "9ef4cbb4fd79eea8356017fad8d26973d9b7b1c0b1725eacd11d360ab09966d8"
+content-hash = "f74e875d3957b05ec8e6f3618daecc2dfa9c8539d743d08c605fc6a1d749213b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dacite = "^1.6.0"
 redo = "^2.0.4"
 notifications-python-client = "^6.4.1"
 requests = "^2.31.0"
-blaise-restapi = {git = "https://github.com/ONSdigital/blaise-api-python-client.git", branch = "main"}
+blaise-restapi = {git = "https://github.com/ONSdigital/blaise-api-python-client.git", rev = "b66777bd0be8f562c7e519e16808fd4e9fadc6d2"}
 google-cloud-logging = "^3.3.0"
 flask = ">=1.0,<3.0"
 


### PR DESCRIPTION
Auto generated by concourse:

Promote from python-client-use-release to main